### PR TITLE
auto startup & shutdown

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,8 @@ primary_region = 'den'
 [[services]]
   protocol = 'tcp'
   internal_port = 25565
+  auto_stop_machines = "stop"
+  auto_start_machines = true
 
 [[services.ports]]
     port = 25565

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ primary_region = 'den'
 [[services]]
   protocol = 'tcp'
   internal_port = 25565
-  auto_stop_machines = "stop"
+  auto_stop_machines = 'stop'
   auto_start_machines = true
 
 [[services.ports]]


### PR DESCRIPTION
The server now automatically starts up and shuts down when activity cannot be detected.
Some potential issues with this:
- The Minecraft server is not actually shut down, the Docker image is just suspended.
- The setup will remain online if a player does DDOS the server.

However, this is probably better than leaving it online forever.